### PR TITLE
Jerometerrier add color name and brightness

### DIFF
--- a/flashing_lights.yaml
+++ b/flashing_lights.yaml
@@ -31,6 +31,14 @@ blueprint:
       default: red
       selector:
         text:
+    brightness:
+      name: brightness
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
 
 mode: restart
 max_exceeded: silent
@@ -59,6 +67,7 @@ action:
     target: !input target_lights
     data: 
       color_name: !input color
+      brightness_pct: !input brightness
   - repeat:
       while:
       - condition: template


### PR DESCRIPTION
Hello
i purpose you a pull request to add two features: 
- the color name : css color name like red or green (https://www.w3.org/TR/css-color-3/#svg-color)
- the brightness : data attribute "brightness_pct" (beetween 0 and 100%)

